### PR TITLE
Kerberos: Allow the KRB5 OID as well as the SPNEGO OID

### DIFF
--- a/src/main/java/com/floragunn/dlic/auth/http/kerberos/HTTPSpnegoAuthenticator.java
+++ b/src/main/java/com/floragunn/dlic/auth/http/kerberos/HTTPSpnegoAuthenticator.java
@@ -47,6 +47,7 @@ import org.ietf.jgss.GSSCredential;
 import org.ietf.jgss.GSSException;
 import org.ietf.jgss.GSSManager;
 import org.ietf.jgss.GSSName;
+import org.ietf.jgss.Oid;
 
 import com.floragunn.dlic.auth.http.kerberos.util.JaasKrbUtil;
 import com.floragunn.dlic.auth.http.kerberos.util.KrbConstants;
@@ -208,9 +209,10 @@ public class HTTPSpnegoAuthenticator implements HTTPAuthenticator {
                     final int credentialLifetime = GSSCredential.INDEFINITE_LIFETIME;
 
                     final PrivilegedExceptionAction<GSSCredential> action = new PrivilegedExceptionAction<GSSCredential>() {
+			final Oid[] oidList = new Oid[]{KrbConstants.SPNEGO, KrbConstants.KRB5MECH};
                         @Override
                         public GSSCredential run() throws GSSException {
-                            return manager.createCredential(null, credentialLifetime, KrbConstants.SPNEGO, GSSCredential.ACCEPT_ONLY);
+                            return manager.createCredential(null, credentialLifetime, oidList, GSSCredential.ACCEPT_ONLY);
                         }
                     };
                     gssContext = manager.createContext(Subject.doAs(subject, action));

--- a/src/main/java/com/floragunn/dlic/auth/http/kerberos/util/KrbConstants.java
+++ b/src/main/java/com/floragunn/dlic/auth/http/kerberos/util/KrbConstants.java
@@ -21,15 +21,19 @@ public final class KrbConstants {
 
  static {
      Oid spnegoTmp = null;
+     Oid krbTmp = null;
      try {
          spnegoTmp = new Oid("1.3.6.1.5.5.2");
+	 krbTmp = new Oid("1.2.840.113554.1.2.2");
      } catch (final GSSException e) {
 
      }
      SPNEGO = spnegoTmp;
+     KRB5MECH = krbTmp;
  }
 
  public static final Oid SPNEGO;
+ public static final Oid KRB5MECH;
  public static final String KRB5_CONF_PROP = "java.security.krb5.conf";
  public static final String JAAS_LOGIN_CONF_PROP = "java.security.auth.login.config";
  public static final String USE_SUBJECT_CREDS_ONLY_PROP = "javax.security.auth.useSubjectCredsOnly";


### PR DESCRIPTION
This allows HTTP clients that use the older, bare OID to work correctly.
